### PR TITLE
Correct month for Amsterdam Collaborator Summit

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Free!
 Although the summits may be coordinated with other events/confrences, you do not need to pay/attend those events to participate in a summit.
 
 ## Upcoming Events
-- [Aug 17-18 2016, Amsterdam, Netherlands](https://github.com/nodejs/summit/issues/16)
+- [Sep 17-18 2016, Amsterdam, Netherlands](https://github.com/nodejs/summit/issues/16)
 - Dec 01-02 2016, Austin, Texas, USA
 
 ## Past Events


### PR DESCRIPTION
Amsterdam Collaborator Summit is in September, not August.