### PR TITLE
typo: Fix Typo on Collab Summit dates on README.md (Change to reflect accurate date of May 31)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Free!
 Although the summits may be coordinated with other events/conferences, you do not need to pay/attend those events to participate in a summit. We also have travel funds for individual members of the Node.js foundation (e.g. Node.js core collaborators) to cover their travel expenses. See [the documentation on travel funds](https://github.com/nodejs/admin/blob/master/MEMBER_TRAVEL_FUND.md) for details.
 
 ## Upcoming Events
-- [May 30-June 01 2018, Berlin, Germany](https://github.com/nodejs/summit/issues/60)
+- [May 31-June 01 2018, Berlin, Germany](https://github.com/nodejs/summit/issues/60)
 
 ## Past Events
 - [Oct 06-07 2017, Vancouver, British Columbia, Canada](https://github.com/nodejs/summit/issues/44)


### PR DESCRIPTION
Changed date from May 30 start to May 31 on README.md