### PR TITLE
Create SESSION_FACILITATOR_GUIDE.md

### DIFF
--- a/SESSION_FACILITATOR_GUIDE.md
+++ b/SESSION_FACILITATOR_GUIDE.md
@@ -1,0 +1,31 @@
+# 💁🏽 Session Facilitator Guide
+
+This document is intended to provide a helpful starting point or reference for running sessions during summits.
+The new learnings and tools from a summit will ideally be PR'd in when each is concluded.
+
+🎉 Lists are included 🎉
+
+## 📅 in the days leading up to the session
+- [ ] If applicable, port the agenda into [tcq](https://tcq.app/)
+- [ ] Set a chair/facilitator for the session
+
+## 🛫 pre-flight checklist (when about to begin the session)
+- [ ]  If not pre-arranged, find consensus on a chair for the session. Scheduled sessions are likely to already have a facilitator/chair. Ad-hoc sessions will need someone to make sure everyone walks out of the room with actionable items.
+- [ ] If not pre-arranged, ask the table for volunteer note taker.
+- [ ] Have a person be take charge of each tool being used for the session. For a full list of tools see below.
+- [ ] Go to Zoom, start the call.
+- [ ] In Zoom, make sure the link to the zoom session is posted on the relevant thread in [nodejs/summit](https://github.com/nodejs/summit/issues/).
+- [ ] In Zoom, start recording the session.
+- [ ] Go to Otter, start recording the audio.
+
+## 🛠 tools for effective sessions
+
+1. [tcq](https://tcq.app/): for facilitating onsite and remote discussion during the sessions
+2. [zoom](https://zoom.us/signin): for video conferencing in remote participants and recording the sessions. Here are [links](https://support.zoom.us/hc/en-us/sections/200208179-Recording) to docs for recording the zoom sessions.
+3. [google hangouts](https://hangouts.google.com): an alternative to zoom, without recording functionality
+4. [otter](https://otter.ai): is for recording meeting audio and complementing the note-taker's efforts
+
+## 🛬 Post-session checklist
+
+- [ ] Chair/facilitator syncs up with participants and note-takers.
+- [ ] Action items are posted as a comment in summit issues and linked to in the relevant repos.

--- a/SESSION_FACILITATOR_GUIDE.md
+++ b/SESSION_FACILITATOR_GUIDE.md
@@ -15,7 +15,8 @@ The new learnings and tools from a summit will ideally be PR'd in when each is c
 - [ ] Have a person be take charge of each tool being used for the session. For a full list of tools see below.
 - [ ] Go to Zoom, start the call.
 - [ ] In Zoom, make sure the link to the zoom session is posted on the relevant thread in [nodejs/summit](https://github.com/nodejs/summit/issues/).
-- [ ] In Zoom, start recording the session.
+- [ ] In Zoom, start recording the session. If the available Zoom accounts are maxed out, use Hangouts.
+- 
 - [ ] (Optional) Go to [Otter](https://otter.ai), start recording the audio.
 
 ## 🛠 tools for effective sessions
@@ -30,3 +31,4 @@ The new learnings and tools from a summit will ideally be PR'd in when each is c
 - [ ] Chair/facilitator syncs up with participants and note-takers.
 - [ ] Action items are posted as a comment in summit issues and linked to in the relevant repos.
 - [ ] Relevant teams and working groups are pinged using Github mentions. Note that teams not originally involved in the session may now need to be looped in if it became relevant during the session.
+- [ ] (optional) If your sessions were not automatically published to youtube, please do that

--- a/SESSION_FACILITATOR_GUIDE.md
+++ b/SESSION_FACILITATOR_GUIDE.md
@@ -6,17 +6,17 @@ The new learnings and tools from a summit will ideally be PR'd in when each is c
 🎉 Lists are included 🎉
 
 ## 📅 in the days leading up to the session
-- [ ] If applicable, port the agenda into [tcq](https://tcq.app/)
 - [ ] Set a chair/facilitator for the session
+- [ ] (optional) if your session is open ended where a broader issue is discussed, you may choose to prepare [tcq](https://tcq.app/) to facilitate discussion
 
 ## 🛫 pre-flight checklist (when about to begin the session)
-- [ ]  If not pre-arranged, find consensus on a chair for the session. Scheduled sessions are likely to already have a facilitator/chair. Ad-hoc sessions will need someone to make sure everyone walks out of the room with actionable items.
+- [ ] The facilitator is the person whose name is listed in the agenda. Facilitators will need to make sure the group walks out of the room with actionable items.
 - [ ] If not pre-arranged, ask the table for volunteer note taker.
 - [ ] Have a person be take charge of each tool being used for the session. For a full list of tools see below.
 - [ ] Go to Zoom, start the call.
 - [ ] In Zoom, make sure the link to the zoom session is posted on the relevant thread in [nodejs/summit](https://github.com/nodejs/summit/issues/).
 - [ ] In Zoom, start recording the session.
-- [ ] Go to Otter, start recording the audio.
+- [ ] (Optional) Go to [Otter](https://otter.ai), start recording the audio.
 
 ## 🛠 tools for effective sessions
 
@@ -29,3 +29,4 @@ The new learnings and tools from a summit will ideally be PR'd in when each is c
 
 - [ ] Chair/facilitator syncs up with participants and note-takers.
 - [ ] Action items are posted as a comment in summit issues and linked to in the relevant repos.
+- [ ] Relevant teams and working groups are pinged using Github mentions. Note that teams not originally involved in the session may now need to be looped in if it became relevant during the session.


### PR DESCRIPTION
Creating this document as a one-stop resource for session chairs/facilitators and participants to use when running a session.

This is a partial proposal (addressing #111) for a process to make achieving productive summits more straightforward.

Note: As of this PR, [tcq](https://tcq.app/) is down.

Commit contains:
* List tools and uses
* Add content for prep, pre-flight, and post-session checklists