### PR TITLE
add tooling group meeting to 2018 agenda

### DIFF
--- a/2018-10-Vancouver/agenda.md
+++ b/2018-10-Vancouver/agenda.md
@@ -37,7 +37,7 @@ _We are expecting 300 people to participate_.
 | 3:30          | Main         | Moderation                                    | @hackygolucky                          | |
 | 3:30          | Main         | Mentorship                                    | @Bamieh                                | |
 | 3:30          | Main         | LTS + release                                          |    @MylesBorins          | https://github.com/nodejs/Release/issues/358  |
-| 3:30          | Main         | Free                                          |                                        | |
+| 3:30          | Main         | Tooling                                          | @boneskull                                       | https://github.com/nodejs/tooling/issues/4 |
 | 3:30          | Main         | Free                                          |                                        | |
 | 3:30          | Breakout 1   | Diagnostics                                   | @kjin , @yunong                   | https://github.com/nodejs/diagnostics/issues/229 |
 | 3:30          | Breakout 2   | Promises                                      | @BridgeAR                              | |


### PR DESCRIPTION
I'm not sure if this was what @mcollina wanted me to do, but here it is.  :wink: Hopefully we won't be jockeying for attention with other groups at the same time...

I'm not sure I'll be able to attend on the 13th, so prefer a time on the 12th.