### PR TITLE
Add CFP issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/summit-topic-proposal.md
+++ b/.github/ISSUE_TEMPLATE/summit-topic-proposal.md
@@ -21,4 +21,11 @@ Please feel free to link to any other issue, PR, or resource that could be relev
 **Describe the session**
 
 
+**Session facilitator(s) and Github handle(s)** 
+
+<!--
+Here's a handy [guide](https://github.com/nodejs/summit/blob/master/SESSION_FACILITATOR_GUIDE.md) for the person or persons who will facilitate this session.
+-->
+
+
 **Additional context (optional)**

--- a/.github/ISSUE_TEMPLATE/summit-topic-proposal.md
+++ b/.github/ISSUE_TEMPLATE/summit-topic-proposal.md
@@ -11,7 +11,7 @@ Thank you! You are submitting a topic for the next Collaborator's Summit, Berlin
 
 Please include as much detail as you are able to at this moment. Don't worry, it doesn't have to be complete.
 
-Please feel free to link to any other issue, PR, resource that could be relevant.
+Please feel free to link to any other issue, PR, or resource that could be relevant.
 
 **Topic of the session**
 

--- a/.github/ISSUE_TEMPLATE/summit-topic-proposal.md
+++ b/.github/ISSUE_TEMPLATE/summit-topic-proposal.md
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 
-Thank you! You are submitting a topic for the next Collaborator's Summit, Berlin 2019!
+Thank you! You are submitting a topic for the next Collaborator's Summit, Berlin 2019! After you send this, feel free to compile https://github.com/nodejs/summit/issues/149 with some information. That form will help us in collecting the information for the agenda.
 
 Please include as much detail as you are able to at this moment. Don't worry, it doesn't have to be complete.
 

--- a/.github/ISSUE_TEMPLATE/summit-topic-proposal.md
+++ b/.github/ISSUE_TEMPLATE/summit-topic-proposal.md
@@ -1,0 +1,22 @@
+---
+name: "\U+270F Summit Topic Proposal"
+about: Submit a topic proposal for a session at the Collab Summit
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+Thank you! You are submitting a topic for the next Collaborator's Summit, Berlin 2019!
+
+Please include as much detail as you are able to at this moment. Don't worry, it doesn't have to be complete.
+
+Please feel free to link to any other issue, PR, resource that could be relevant.
+
+**Topic of the session**
+
+
+**Describe the session**
+
+
+**Additional context (optional)**

--- a/.github/ISSUE_TEMPLATE/summit-topic-proposal.md
+++ b/.github/ISSUE_TEMPLATE/summit-topic-proposal.md
@@ -7,11 +7,13 @@ assignees: ''
 
 ---
 
+<!--
 Thank you! You are submitting a topic for the next Collaborator's Summit, Berlin 2019! After you send this, feel free to compile https://github.com/nodejs/summit/issues/149 with some information. That form will help us in collecting the information for the agenda.
 
 Please include as much detail as you are able to at this moment. Don't worry, it doesn't have to be complete.
 
 Please feel free to link to any other issue, PR, or resource that could be relevant.
+-->
 
 **Topic of the session**
 


### PR DESCRIPTION
The open CFP in #149 lists the Form we are using to collect submissions. I've gotten feedback that there is some confusion about whether submitting through Github issues is still an option. It is! 

So this PR adds a CFP issue template so folks can submit CFPs easier.