### PR TITLE
Update summit session proposal

### DIFF
--- a/.github/ISSUE_TEMPLATE/summit-topic-proposal.md
+++ b/.github/ISSUE_TEMPLATE/summit-topic-proposal.md
@@ -1,14 +1,14 @@
 ---
 name: Summit Topic Proposal
 about: Submit a topic proposal for a session at the Collab Summit
-title: ''
-labels: ''
-assignees: ''
+title: 'Summit Topic: '
+labels: Montreal 2019, Collaborator Summit, Session Proposal
+assignees: christian-bromann, evahowe, jorydotcom, keywordnew
 
 ---
 
 <!--
-Thank you! You are submitting a topic for the next Collaborator's Summit, Berlin 2019! After you send this, feel free to compile https://github.com/nodejs/summit/issues/149 with some information. That form will help us in collecting the information for the agenda.
+Thank you! You are submitting a topic for the next Collaborator's Summit, Montreal 2020!
 
 Please include as much detail as you are able to at this moment. Don't worry, it doesn't have to be complete.
 
@@ -21,7 +21,7 @@ Please feel free to link to any other issue, PR, or resource that could be relev
 **Describe the session**
 
 
-**Session facilitator(s) and Github handle(s)** 
+**Session facilitator(s) and Github handle(s)**
 
 <!--
 Here's a handy [guide](https://github.com/nodejs/summit/blob/master/SESSION_FACILITATOR_GUIDE.md) for the person or persons who will facilitate this session.

--- a/.github/ISSUE_TEMPLATE/summit-topic-proposal.md
+++ b/.github/ISSUE_TEMPLATE/summit-topic-proposal.md
@@ -8,7 +8,7 @@ assignees: christian-bromann, evahowe, jorydotcom, keywordnew
 ---
 
 <!--
-Thank you! You are submitting a topic for the next Collaborator's Summit, Montreal 2020!
+Thank you! You are submitting a topic for the next Collaborator's Summit, Montreal 2019!
 
 Please include as much detail as you are able to at this moment. Don't worry, it doesn't have to be complete.
 


### PR DESCRIPTION
This patch updates the summit proposal template. I added Manil, Jory, Eva and me as "assignees" so we get notified and keep updated on the number of proposals that come in. In addition to that every proposal is tagged properly so that we can easily generate a list of proposals that were made.